### PR TITLE
Remove lookahead clauses in LITERAL

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -12,7 +12,8 @@
                  [org.clojure/data.json "0.2.6"]
                  [edn-ld "0.2.2"]]
   :plugins [[lein-cljsbuild "1.1.3"]
-            [lein-project-version "0.1.0"]]
+            [lein-project-version "0.1.0"]
+            [lein-cljfmt "0.5.3"]]
   :main howl.cli
   :aot [howl.cli]
   :manifest {"Implementation-Version" ~project-version}

--- a/src/howl/cli.clj
+++ b/src/howl/cli.clj
@@ -22,6 +22,7 @@
      (fn [state line]
        (->> (core/merge-line state line)
             core/parse-block
+            core/preprocess-block
             core/annotate-block))
      {:file-name file-name}
      (line-seq reader))))

--- a/src/howl/core.cljc
+++ b/src/howl/core.cljc
@@ -212,7 +212,7 @@
     OBJECT     = BLANK_NODE / PREFIXED_NAME / WRAPPED_IRI / ABSOLUTE_IRI / LABEL
     DATATYPE   = PREFIXED_NAME / WRAPPED_IRI / ABSOLUTE_IRI / LABEL
     LITERAL    = CHAR+ LANG /
-                 CHAR+ <'^^'> DATATYPE /
+                 CHAR+ '^^' DATATYPE /
                  #'(\n|.)*.+'
 
     PREFIX        = #'(\\w|-)+'
@@ -286,20 +286,18 @@
 (defn preprocess-block
   "Given a state map,
    if it has a :block key with a :parse key,
-   run some post-processing steps on the :parse."
+   run some post-processing steps on the :parse.
+   Currently, this collapses :LITERAL_BLOCK characters into a string. It will
+   eventuallly run additional pre-annotation tasks."
   [state]
-  (println "COLLAPSING")
   (if-let [parse (get-in state [:block :parse])]
-    (do (println " DEALING WITH" parse)
-     (case (first parse)
-       :LITERAL_BLOCK  (do
-                        (println "   LITERAL BLOCK!")
-                        (assoc
-                         state
-                         :block
-                         (merge (get state :block)
-                                {:parse (preprocess-literal parse)})))
-       state))
+    (case (first parse)
+      :LITERAL_BLOCK  (assoc
+                       state
+                       :block
+                       (merge (get state :block)
+                              {:parse (preprocess-literal parse)}))
+      state)
     state))
 
 ;; Once we have the parse vector,

--- a/src/howl/core.cljc
+++ b/src/howl/core.cljc
@@ -211,8 +211,8 @@
     PREDICATE  = PREFIXED_NAME / WRAPPED_IRI / ABSOLUTE_IRI / LABEL
     OBJECT     = BLANK_NODE / PREFIXED_NAME / WRAPPED_IRI / ABSOLUTE_IRI / LABEL
     DATATYPE   = PREFIXED_NAME / WRAPPED_IRI / ABSOLUTE_IRI / LABEL
-    LITERAL    = #'.+(?=@(\\w|-)+)' LANG /
-                 #'.+(?=\\^\\^\\S+)' '^^' DATATYPE /
+    LITERAL    = CHAR+ LANG /
+                 CHAR+ <'^^'> DATATYPE /
                  #'(\n|.)*.+'
 
     PREFIX        = #'(\\w|-)+'
@@ -228,6 +228,7 @@
     ARROWS        = #'>*' #'\\s*'
     LABEL         = #'[^:\n]+'
     EOL           = #'(\r|\n|\\s)*'
+    <CHAR> = #'.'
     "))
 
 (defn instaparse-reason
@@ -274,6 +275,32 @@
         (assoc-in state [:block :parse] (second parse))))
     state))
 
+(defn preprocess-literal [literal-block-parse]
+  (map
+   (fn [elem]
+     (if (and (vector? elem) (= :LITERAL (first elem)))
+       [:LITERAL (string/join (drop 1 (butlast elem))) (last elem)]
+       elem))
+   literal-block-parse))
+
+(defn preprocess-block
+  "Given a state map,
+   if it has a :block key with a :parse key,
+   run some post-processing steps on the :parse."
+  [state]
+  (println "COLLAPSING")
+  (if-let [parse (get-in state [:block :parse])]
+    (do (println " DEALING WITH" parse)
+     (case (first parse)
+       :LITERAL_BLOCK  (do
+                        (println "   LITERAL BLOCK!")
+                        (assoc
+                         state
+                         :block
+                         (merge (get state :block)
+                                {:parse (preprocess-literal parse)})))
+       state))
+    state))
 
 ;; Once we have the parse vector,
 ;; we process that into a nicer "block map".

--- a/test/test2.howl
+++ b/test/test2.howl
@@ -1,0 +1,3 @@
+comment: A comment on 'Foo'.@en
+> comment: An annotation on a comment.^^xsd:string
+>> comment: An annotation on an annotation.^^xsd:string


### PR DESCRIPTION
- Introduce new <CHAR>
- Use CHAR+ instead of lookahead regex
- Add preprocess-block step to collapse resulting character sequences
- Call preprocess-block in parse-howl-file
- Add test2.howl to the testing resources (Not sure if we'll want to
  write smoke-tests using this parse-a-file approach, or if it would be
  better to write generators. Leaning towards the latter, but still
  isolating this snippet)
